### PR TITLE
Enable elm-review on the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "tdd-js": "nodemon --watch '*' --watch 'cli-src/**/*' -e js,mjs  --exec 'npm run test-js'",
         "test": "npm run test-elm && npm run test-js",
         "test-all": "npm run test-elm && npm run test-js",
-        "test-elm": "elm-verify-examples && elm-app test",
+        "test-elm": "elm-verify-examples && elm-app test && npm run test-elm-review",
+        "test-elm-review": "elm-review",
         "test-js": "rm -rf tests/unit/assets/temp; node tests/unit.mjs | tap-diff; rm -rf assets/temp"
     },
     "dependencies": {

--- a/review/elm.json
+++ b/review/elm.json
@@ -1,0 +1,34 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/project-metadata-utils": "1.0.1",
+            "jfmengels/elm-review": "2.3.11",
+            "jfmengels/elm-review-unused": "1.1.7",
+            "stil4m/elm-syntax": "7.2.2"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/list-extra": "8.3.0",
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-hex": "1.0.0",
+            "stil4m/structured-writer": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {}
+    }
+}

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -1,0 +1,30 @@
+module ReviewConfig exposing (config)
+
+{-| Do not rename the ReviewConfig module or the config function, because
+`elm-review` will look for these.
+
+To add packages that contain rules, add them to this review project using
+
+    `elm install author/packagename`
+
+when inside the directory containing this file.
+
+-}
+
+import NoUnused.Variables
+import Review.Rule as Rule exposing (Rule)
+
+
+config : List Rule
+config =
+    [ NoUnused.Variables.rule
+
+    --, NoUnused.CustomTypeConstructors.rule []
+    --, NoUnused.CustomTypeConstructorArgs.rule
+    --, NoUnused.Dependencies.rule
+    --, NoUnused.Exports.rule
+    --, NoUnused.Modules.rule
+    --, NoUnused.Parameters.rule
+    --, NoUnused.Patterns.rule
+    ]
+        |> List.map (Rule.ignoreErrorsForFiles [ "src/Viewport.elm", "src/Ui/Boxicons", "src/Ui/EntypoIcons.elm" ])


### PR DESCRIPTION
Hey all :wave:

This adds `elm-review` to the project, based on @FranzSkuffka's request.

There is currently only one rule enabled. I recommend fixing the issues, then enabling an additional rule, and so on.

I was **not** able to install `elm-review` (or any npm dependency for that matter), because I get an error like this
```
$ npm install -S elm-review
npm ERR! Unexpected end of JSON input while parsing near '...ue
npm ERR!         }
npm ERR!     }
npm ERR! }
npm ERR! '
```

I don't know how you manage to install dependencies, but running `npm install -S elm-review` should be sufficient to complete the PR.

The next steps would be to fix the issues reported here. There are about 220 errors, and at least 1200 more when enabling the other rules. You can use `elm-review --fix` to apply automatic fixes.

Note that I had to ignore the Git hooks because  `elm-review` made the tests fail.

My personal opinion is that you won't need either `elm-analyse` nor `elm-impfix` once you're done adopting `elm-review`, though you'll need to add more rules to the configuration to match what `elm-analyse` is reporting (and you can find those in the Elm package registry).

### Side-note

If I may add a side-note that is my personal opinion: I think you should really run tests inside a CI for this project. I notice that you have `elm-analyse` and `elm-impfix` enabled on the project, but they are both reporting issues, and so is `elm-format`. Git hooks can be nice to help make each commit work well, but they are not a good enough safety net, and whatever passes through one day will remain. (And, personal opinion, they make doing tiny commits very slow. TBH it wasn't a very pleasant experience to do these commits with Git Hooks).


I hope you'll find `elm-review` to give you a delightful experience, and let me know if you have any feedback about the tool!